### PR TITLE
Making the timer more efficient and fixing a load issue

### DIFF
--- a/hms-app/src/components/Timer.js
+++ b/hms-app/src/components/Timer.js
@@ -1,42 +1,43 @@
 import React, { useEffect, useState } from 'react'
 
+const MILLIS_PER_MINUTE = 1000 * 60;
+const MILLIS_PER_HOUR = MILLIS_PER_MINUTE * 60;
+const MILLIS_PER_DAY = MILLIS_PER_HOUR * 24;
+
+function getFormattedCountdown(countDownDate) {
+	let millisRemaining = countDownDate - new Date().getTime();
+
+	if (millisRemaining <= 0) {
+        return "0:00:00:00";
+	}
+
+    let days = Math.floor(millisRemaining/MILLIS_PER_DAY);
+
+    let hours = Math.floor((millisRemaining % MILLIS_PER_DAY)/MILLIS_PER_HOUR);
+    hours = hours < 10 ? "0" + hours : hours
+
+    let minutes = Math.floor((millisRemaining % MILLIS_PER_HOUR)/MILLIS_PER_MINUTE);
+    minutes = minutes < 10 ? "0" + minutes : minutes
+
+    let seconds = Math.floor((millisRemaining % MILLIS_PER_MINUTE)/1000);
+    seconds = seconds < 10 ? "0" + seconds : seconds
+
+	return days + ":" + hours + ":" + minutes + ":" + seconds;
+}
+
 const Timer = ({ countDownDateTime }) => {
 	let countDownDate = countDownDateTime ? new Date(countDownDateTime).getTime() : ''
 
-	const [timeLeft, setTimeLeft] = useState(countDownDate);
+	const [timeLeft, setTimeLeft] = useState(getFormattedCountdown(countDownDate));
 
 	useEffect(() => {
 		// exit early when we reach 0
 		if (!timeLeft) return;
 
-		let now = new Date().getTime();
-		let distance = countDownDate - now;
-		let days = Math.floor(distance / (1000 * 60 * 60 * 24));
-		let hours = Math.floor((distance % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
-		let minutes = Math.floor((distance % (1000 * 60 * 60)) / (1000 * 60));
-		let seconds = Math.floor((distance % (1000 * 60)) / 1000);
-
-		if (distance <= 0) {
-			days = 0;
-			hours = 0;
-			minutes = 0;
-			seconds = 0;
-		}
-
-		if (hours < 10) {
-			hours = "0" + hours
-		}
-		if (minutes < 10) {
-			minutes = "0" + minutes
-		}
-		if (seconds < 10) {
-			seconds = "0" + seconds
-		}
-
 		// save intervalId to clear the interval when the
 		// component re-renders
 		const intervalId = setInterval(() => {
-			setTimeLeft(days + ":" + hours + ":" + minutes + ":" + seconds);
+			setTimeLeft(getFormattedCountdown(countDownDate));
 		}, 1000);
 
 		// clear interval on re-render to avoid memory leaks

--- a/hms-app/src/components/Timer.js
+++ b/hms-app/src/components/Timer.js
@@ -1,54 +1,54 @@
-import React, { useEffect, useState } from 'react'
+import React, {useEffect, useState} from 'react'
 
 const MILLIS_PER_MINUTE = 1000 * 60;
 const MILLIS_PER_HOUR = MILLIS_PER_MINUTE * 60;
 const MILLIS_PER_DAY = MILLIS_PER_HOUR * 24;
 
 function getFormattedCountdown(countDownDate) {
-	let millisRemaining = countDownDate - new Date().getTime();
+    let millisRemaining = countDownDate - new Date().getTime();
 
-	if (millisRemaining <= 0) {
+    if (millisRemaining <= 0) {
         return "0:00:00:00";
-	}
+    }
 
-    let days = Math.floor(millisRemaining/MILLIS_PER_DAY);
+    let days = Math.floor(millisRemaining / MILLIS_PER_DAY);
 
-    let hours = Math.floor((millisRemaining % MILLIS_PER_DAY)/MILLIS_PER_HOUR);
+    let hours = Math.floor((millisRemaining % MILLIS_PER_DAY) / MILLIS_PER_HOUR);
     hours = hours < 10 ? "0" + hours : hours
 
-    let minutes = Math.floor((millisRemaining % MILLIS_PER_HOUR)/MILLIS_PER_MINUTE);
+    let minutes = Math.floor((millisRemaining % MILLIS_PER_HOUR) / MILLIS_PER_MINUTE);
     minutes = minutes < 10 ? "0" + minutes : minutes
 
-    let seconds = Math.floor((millisRemaining % MILLIS_PER_MINUTE)/1000);
+    let seconds = Math.floor((millisRemaining % MILLIS_PER_MINUTE) / 1000);
     seconds = seconds < 10 ? "0" + seconds : seconds
 
-	return days + ":" + hours + ":" + minutes + ":" + seconds;
+    return days + ":" + hours + ":" + minutes + ":" + seconds;
 }
 
-const Timer = ({ countDownDateTime }) => {
-	let countDownDate = countDownDateTime ? new Date(countDownDateTime).getTime() : ''
+const Timer = ({countDownDateTime}) => {
+    let countDownDate = countDownDateTime ? new Date(countDownDateTime).getTime() : ''
 
-	const [timeLeft, setTimeLeft] = useState(getFormattedCountdown(countDownDate));
+    const [timeLeft, setTimeLeft] = useState(getFormattedCountdown(countDownDate));
 
-	useEffect(() => {
-		// exit early when we reach 0
-		if (!timeLeft) return;
+    useEffect(() => {
+        // exit early when we reach 0
+        if (!timeLeft) return;
 
-		// save intervalId to clear the interval when the
-		// component re-renders
-		const intervalId = setInterval(() => {
-			setTimeLeft(getFormattedCountdown(countDownDate));
-		}, 1000);
+        // save intervalId to clear the interval when the
+        // component re-renders
+        const intervalId = setInterval(() => {
+            setTimeLeft(getFormattedCountdown(countDownDate));
+        }, 1000);
 
-		// clear interval on re-render to avoid memory leaks
-		return () => clearInterval(intervalId);
-		// add timeLeft as a dependency to re-rerun the effect
-		// when we update it
-	}, [timeLeft]);
+        // clear interval on re-render to avoid memory leaks
+        return () => clearInterval(intervalId);
+        // add timeLeft as a dependency to re-rerun the effect
+        // when we update it
+    }, [timeLeft]);
 
-	return (
-		<span>{timeLeft}</span>
-	);
+    return (
+        <span>{timeLeft}</span>
+    );
 };
 
 export default Timer


### PR DESCRIPTION
When the timer first appeared it would display the start time of the competition in milliseconds and then quickly swap to the formatted time remaining.

These changes should also make the calculation logic a tiny bit more efficient by not having to do as much multiplication and by exiting early without doing any math when the remaining time is <= 0.